### PR TITLE
Let GitHub preview description of conflicting PRs

### DIFF
--- a/scripts/conflicts.py
+++ b/scripts/conflicts.py
@@ -80,7 +80,7 @@ def update_comment(dry_run, pull, pulls_conflict):
     text += "Reviewers, this pull request conflicts with the following ones:\n"
     text += "".join(
         [
-            f"\n* [#{p.CON_id.removeprefix(pull.CON_slug)}]({p.html_url}) ({p.title.strip()} by {p.user.login})"
+            f"\n* {p.html_url} by {p.user.login}"
             for p in pulls_conflict
         ]
     )


### PR DESCRIPTION
Instead of providing an URL to the conflicting PR, let GitHub preview the PR description by simply providing the #number.

![image](https://user-images.githubusercontent.com/22493292/198706990-da13ee7d-4cf9-46df-9825-a72f0be30394.png)

instead of 
![image](https://user-images.githubusercontent.com/22493292/198707027-07920c07-e4d8-478e-8f17-5d8cdeb75ef6.png)
