### PR TITLE
webhook_features: Parse commits with URL with regex

### DIFF
--- a/webhook_features/src/main.rs
+++ b/webhook_features/src/main.rs
@@ -4,7 +4,7 @@ mod features;
 use std::str::FromStr;
 
 use crate::features::summary_comment::SummaryCommentFeature;
-use actix_web::{get, http, post, web, App, HttpRequest, HttpServer, Responder};
+use actix_web::{get, post, web, App, HttpRequest, HttpServer, Responder};
 use clap::Parser;
 use features::Feature;
 use lazy_static::lazy_static;
@@ -109,10 +109,6 @@ async fn main() -> Result<()> {
 
     let octocrab = octocrab::Octocrab::builder()
         .personal_token(args.token)
-        .add_header(
-            http::header::ACCEPT,
-            "application/vnd.github.full+json".to_string(),
-        )
         .build()
         .map_err(DrahtBotError::GitHubError)?;
 


### PR DESCRIPTION
Fixes https://github.com/MarcoFalke/DrahtBot/issues/16#issuecomment-1326758273.
I think it's better to use regex for this anyway as it's more testable and reliable.