### PR TITLE
summary_comment: hide ack table if conceptual review is still needed

### DIFF
--- a/webhook_features/config.yml
+++ b/webhook_features/config.yml
@@ -95,3 +95,4 @@ repositories:
         - '^move-?only:'
         - '^scripted-diff:'
     corecheck: true
+hide_summary_label: "Needs Conceptual Review"

--- a/webhook_features/src/config.rs
+++ b/webhook_features/src/config.rs
@@ -9,4 +9,5 @@ pub struct Repo {
 #[derive(serde::Deserialize)]
 pub struct Config {
     pub repositories: Vec<Repo>,
+    pub hide_summary_label: String,
 }


### PR DESCRIPTION
Addresses https://github.com/bitcoin-core/meta/issues/19#issuecomment-2959293413

If a PR is labeled "Needs Conceptual Review" then DrahtBot will not display the review summary table. The goal is to prevent the misinterpretation that DrahtBot is tallying votes which may in turn encourage low-effort ack/nack spam.

DrahtBot will listen for (un)label events so the table is hidden or displayed right away.

I have this branch of drahtbot running on my own fork if anyone wants to try it out: https://github.com/pinheadmz/bitcoin


Animated gif demo:


![Jun-10-2025 13-38-09](https://github.com/user-attachments/assets/a4282ac5-5c3b-4277-93c0-ee9a0f244b39)
