### PR TITLE
Link past ACKs to a collapsible history section

### DIFF
--- a/webhook_features/src/features/summary_comment.rs
+++ b/webhook_features/src/features/summary_comment.rs
@@ -118,7 +118,7 @@ impl Feature for SummaryCommentFeature {
 
 const BOT_SKIP_TAG: &str = "<!--meta-tag:bot-skip-->";
 
-fn summary_comment_template(reviews: Vec<Review>) -> String {
+fn summary_comment_template(reviews: Vec<Review>, history: Vec<Review>) -> String {
     let review_url = "https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#code-review";
     let mut comment = format!(
         r#"
@@ -159,11 +159,21 @@ See [the guideline]({review_url}) for information on the review process.
                     ack_type.as_str(),
                     users
                         .iter()
-                        .map(|(user, url, _)| format!("[{user}]({url})"))
+                        .map(|(user, url, _)| format_ack(user, url))
                         .collect::<Vec<_>>()
                         .join(", ")
                 );
             }
+        }
+
+        if !history.is_empty() {
+            comment += "\n<details><summary>Review history</summary>\n\n";
+            comment += "| Type | Reviewer | Date |\n";
+            comment += "| ---- | -------- | ---- |\n";
+            for Review { ack_type, user, url, date } in history {
+                comment += &format!("| {} | {} | {} |\n", ack_type.as_str(), format_ack(&user, &url), date.format("%F"));
+            }
+            comment += "\n</details>\n";
         }
 
         comment += "\n";
@@ -176,6 +186,8 @@ See [the guideline]({review_url}) for information on the review process.
     comment
 }
 
+fn format_ack(user: &String, url: &String) -> String { format!("[{user}]({url})") }
+
 struct GitHubReviewComment {
     user: String,
     url: String,
@@ -187,7 +199,7 @@ fn collect_user_reviews(
     all_comments: Vec<GitHubReviewComment>,
     pr_author: &str,
     head_commit: &str,
-) -> Vec<Review> {
+) -> (Vec<Review>, Vec<Review>) {
     let mut user_reviews: HashMap<String, Vec<Review>> = HashMap::new(); // Need to store all acks per user to avoid duplicates
 
     for comment in all_comments.into_iter() {
@@ -212,7 +224,15 @@ fn collect_user_reviews(
         }
     }
 
-    user_reviews
+    let mut history = user_reviews
+        .values()
+        .flatten()
+        .filter(|r| r.ack_type != AckType::Ignored)
+        .cloned()
+        .collect::<Vec<_>>();
+    history.sort_by_key(|r| r.date);
+
+    let reviews = user_reviews
         .into_iter()
         .map(|e| {
             let e = e.1;
@@ -225,7 +245,9 @@ fn collect_user_reviews(
                 e.into_iter().max_by_key(|r| r.date).unwrap()
             }
         })
-        .collect::<Vec<_>>()
+        .collect::<Vec<_>>();
+
+    (reviews, history)
 }
 
 async fn refresh_summary_comment(
@@ -335,7 +357,7 @@ For details see: https://corecheck.dev/{owner}/{repo}/pulls/{pull_num}.
     );
 
     let pr_author = pr.user.unwrap().login;
-    let user_reviews = collect_user_reviews(all_comments, &pr_author, &head_commit);
+    let (user_reviews, history) = collect_user_reviews(all_comments, &pr_author, &head_commit);
 
     let max_ack_date = user_reviews
         .iter()
@@ -378,7 +400,7 @@ For details see: https://corecheck.dev/{owner}/{repo}/pulls/{pull_num}.
         .map(|r| r.user.clone())
         .collect::<Vec<_>>();
 
-    let comment = summary_comment_template(user_reviews);
+    let comment = summary_comment_template(user_reviews, history);
     util::update_metadata_comment(
         &issues_api,
         &mut cmt,
@@ -529,7 +551,7 @@ mod tests {
     use chrono::TimeZone;
 
     #[test]
-    fn test_summary_comment_template() {
+    fn test_summary_comment_template_includes_history() {
         let reviews = vec![Review {
             user: "user".to_string(),
             ack_type: AckType::Ack,
@@ -537,7 +559,22 @@ mod tests {
             date: chrono::Utc.with_ymd_and_hms(2026, 1, 2, 0, 0, 0).unwrap(),
         }];
 
-        let text = summary_comment_template(reviews);
+        let history = vec![
+            Review {
+                user: "user".to_string(),
+                ack_type: AckType::ConceptAck,
+                url: "https://example.com/review/old".to_string(),
+                date: chrono::Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+            },
+            Review {
+                user: "user".to_string(),
+                ack_type: AckType::Ack,
+                url: "https://example.com/review".to_string(),
+                date: chrono::Utc.with_ymd_and_hms(2026, 1, 2, 0, 0, 0).unwrap(),
+            },
+        ];
+
+        let text = summary_comment_template(reviews, history);
         assert_eq!(
             text,
             r#"
@@ -546,6 +583,15 @@ See [the guideline](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.
 | Type | Reviewers |
 | ---- | --------- |
 | ACK | [user](https://example.com/review) |
+
+<details><summary>Review history</summary>
+
+| Type | Reviewer | Date |
+| ---- | -------- | ---- |
+| Concept ACK | [user](https://example.com/review/old) | 2026-01-01 |
+| ACK | [user](https://example.com/review) | 2026-01-02 |
+
+</details>
 
 If your review is incorrectly listed, please copy-paste <code>&lt;!--meta-tag:bot-skip--&gt;</code> into the comment that the bot should ignore.
 "#


### PR DESCRIPTION
### Context
Inspired by https://github.com/maflcko/DrahtBot/pull/72#issuecomment-3723727786, this adds a dedicated review history section so maintainers can quickly inspect older ACK/NACK context without cluttering the main `Reviews` table.

### Other attempts
I originally tried superscript links and brace-style links next to the latest ACKs, but both were too verbose and hurt readability, so the history is now a separate collapsible section.

### Structure
* First commit adds a test for `summary_comment_template` to lock the `Reviews` markdown format and show the effect of each change.
* Second one unburdens the follow-up change by extracting review parsing/selection into `collect_user_reviews()` to isolate the review selection logic for follow-up history rendering (this also helps with the preview patch below).
* Last commit adds a collapsible `Review history` table listing all non-ignored review events (type, reviewer link, date).

### Reproducer
See https://gist.github.com/l0rinc/484dc5670f6a79a522d39acfa4b83b11 for an example output and apply the following patch to try it with any other PR:
<details><summary>Patch for `--preview-reviews` that fetches a PR’s comments/reviews and prints the generated Reviews markdown</summary>

```patch
diff --git a/webhook_features/src/features/summary_comment.rs b/webhook_features/src/features/summary_comment.rs
index 7ccbc37..e81bdb9 100644
--- a/webhook_features/src/features/summary_comment.rs
+++ b/webhook_features/src/features/summary_comment.rs
@@ -178,6 +178,54 @@ struct GitHubReviewComment {
     date: chrono::DateTime<chrono::Utc>,
 }
 
+pub async fn preview_reviews_markdown(
+    ctx: &Context,
+    owner: String,
+    repo: String,
+    pr_number: u64,
+) -> Result<String> {
+    let repo = Repository { owner, name: repo };
+    let issues_api = ctx.octocrab.issues(&repo.owner, &repo.name);
+    let pulls_api = ctx.octocrab.pulls(&repo.owner, &repo.name);
+    let pr = pulls_api.get(pr_number).await?;
+
+    let all_comments = ctx
+        .octocrab
+        .all_pages(issues_api.list_comments(pr_number).send().await?)
+        .await?;
+    let cmt = util::get_metadata_sections_from_comments(&all_comments, pr_number);
+
+    let mut all_comments = all_comments
+        .into_iter()
+        .filter(|c| cmt.id != Some(c.id))
+        .map(|c| GitHubReviewComment {
+            user: c.user.login,
+            url: c.html_url.to_string(),
+            body: c.body.unwrap_or_default(),
+            date: c.updated_at.unwrap_or(c.created_at),
+        })
+        .collect::<Vec<_>>();
+    let mut all_review_comments = ctx
+        .octocrab
+        .all_pages(pulls_api.list_reviews(pr_number).send().await?)
+        .await?
+        .into_iter()
+        .filter(|c| c.user.is_some())
+        .map(|c| GitHubReviewComment {
+            user: c.user.unwrap().login,
+            url: c.html_url.to_string(),
+            body: c.body.unwrap_or_default(),
+            date: c.submitted_at.unwrap(),
+        })
+        .collect::<Vec<_>>();
+    all_comments.append(&mut all_review_comments);
+
+    let head_commit = pr.head.sha;
+    let pr_author = pr.user.unwrap().login;
+    let user_reviews = collect_user_reviews(all_comments, &pr_author, &head_commit);
+    Ok(summary_comment_template(user_reviews))
+}
+
 fn collect_user_reviews(
     all_comments: Vec<GitHubReviewComment>,
     pr_author: &str,
diff --git a/webhook_features/src/main.rs b/webhook_features/src/main.rs
index 583dc84..4d185f2 100644
--- a/webhook_features/src/main.rs
+++ b/webhook_features/src/main.rs
@@ -35,10 +35,13 @@ struct Args {
     port: u16,
     /// The path to the yaml config file.
     #[arg(long)]
-    config_file: std::path::PathBuf,
+    config_file: Option<std::path::PathBuf>,
     /// Print changes/edits instead of calling the GitHub/CI API.
     #[arg(long, default_value_t = false)]
     dry_run: bool,
+    /// Print the generated Reviews markdown for this pull request and exit. Format: owner/repo/number or https://github.com/owner/repo/pull/number
+    #[arg(long)]
+    preview_reviews: Option<String>,
 }
 
 #[derive(Display, EnumString, PartialEq, Eq, Hash)]
@@ -146,20 +149,71 @@ async fn emit_event(ctx: &Context, event: GitHubEvent, data: web::Json<serde_jso
     num_errors
 }
 
+fn parse_pull_id(s: &str) -> Result<(String, String, u64)> {
+    let err = "Wrong format, expected owner/repo/number or a GitHub PR URL.";
+    let s = s
+        .trim()
+        .split('#')
+        .next()
+        .unwrap_or("")
+        .split('?')
+        .next()
+        .unwrap_or("")
+        .trim_end_matches('/');
+    let s = s
+        .strip_prefix("https://github.com/")
+        .or_else(|| s.strip_prefix("http://github.com/"))
+        .unwrap_or(s);
+
+    let parts = s.split('/').filter(|p| !p.is_empty()).collect::<Vec<_>>();
+    let (owner, repo, number) = match parts.as_slice() {
+        [owner, repo, "pull" | "pulls", number] | [owner, repo, number] => (owner, repo, number),
+        _ => return Err(anyhow::anyhow!(err)),
+    };
+
+    Ok((owner.to_string(), repo.to_string(), number.parse::<u64>()?))
+}
+
 #[actix_web::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
 
-    let config: Config = serde_yaml::from_reader(
-        std::fs::File::open(args.config_file).expect("config file path error"),
-    )
-    .expect("yaml error");
-
     let octocrab = octocrab::Octocrab::builder()
         .personal_token(args.token.as_ref())
         .build()
         .map_err(DrahtBotError::GitHubError)?;
 
+    if let Some(pull_id) = args.preview_reviews {
+        let (owner, repo, number) = parse_pull_id(&pull_id)?;
+        let context = Context {
+            octocrab,
+            bot_username: "DrahtBot".to_string(),
+            config: Config {
+                repositories: Vec::new(),
+            },
+            github_token: args.token,
+            llm_token: args.llm_token,
+            dry_run: args.dry_run,
+        };
+        let md = crate::features::summary_comment::preview_reviews_markdown(
+            &context,
+            owner,
+            repo,
+            number,
+        )
+        .await?;
+        print!("{md}");
+        return Ok(());
+    }
+
+    let config_file = args
+        .config_file
+        .expect("--config-file is required unless --preview-reviews is used");
+    let config: Config = serde_yaml::from_reader(
+        std::fs::File::open(config_file).expect("config file path error"),
+    )
+    .expect("yaml error");
+
     println!("{}", list_features());
     println!();

```

</details>

After applying locally, you can test it with: e.g.
```bash
(cd webhook_features && cargo run -- --token "$(gh auth token)" --preview-reviews https://github.com/bitcoin/bitcoin/pull/29415)
```